### PR TITLE
Update kail brew install instructions

### DIFF
--- a/4_logs.adoc
+++ b/4_logs.adoc
@@ -64,7 +64,8 @@ and if you are running Istio make sure to add the -c to specify your business lo
 
 Another option is kail 
 ----
-$ brew install kail
+$ brew tap boz/repo
+$ brew install boz/repo/kail
 $ kail
 ----
 


### PR DESCRIPTION
The instructions in step 4 for installing kail failed for me:

```bash
$ brew install kail
Updating Homebrew...
Error: No available formula with the name "kail" 
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
==> Searching taps on GitHub...
Error: No formulae found in taps.
```

I looked up the instructions at [the kail repo](https://github.com/boz/kail):

```bash
$ brew tap boz/repo
$ brew install boz/repo/kail
```

I confirmed that these instructions work:

```bash
$ brew tap boz/repo
Updating Homebrew...
==> Tapping boz/repo
Cloning into '/usr/local/Homebrew/Library/Taps/boz/homebrew-repo'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 1 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Tapped 2 formulae (29 files, 24.5KB).

$ brew install boz/repo/kail
==> Installing kail from boz/repo
==> Downloading https://github.com/boz/kail/releases/download/v0.10.1/kail_0.10.1_darwin_amd64.tar.gz
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/100161830/d8f65b80-78d2-11e9-81b5-d36a371ab205?X-Amz-Algorithm
######################################################################## 100.0%
🍺  /usr/local/Cellar/kail/0.10.1: 5 files, 29.9MB, built in 6 seconds
```